### PR TITLE
Adjust repositories mode to allow plugin repository

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- update the settings Gradle configuration to prefer settings repositories so plugin-defined repositories are permitted

## Testing
- ./gradlew tasks *(fails: Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_b_68e1ea1d5304832badb1bf35f78cedc3